### PR TITLE
Cursor Position and Reference String 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,19 +4,13 @@ import { simple, full, ancestor, fullAncestor, findNodeAt, findNodeAround, findN
 
 const CURSOR_SYMBOL = '^'
 
-export const returnSuggestions = () => {
-    //TODO
-}
-
 /* 
+fileContents: Input file read as String
 Returns cursor position as denoted by CURSOR_SYMBOL if present
 Returns -1 if no cursor symbol present
 */
-export const getCursorPosition = () => {
-    //TODO
-    const fileContents = readInputFile()
-    const cursorPos = fileContents.indexOf(CURSOR_SYMBOL)
-    return cursorPos
+export const getCursorPosition = (fileContents) => {
+    return fileContents.indexOf(CURSOR_SYMBOL)
 }
 
 const readInputFile = () => {
@@ -32,15 +26,26 @@ export const customParse = () => {
     return parsedResult
 }
 
-const cursorPosition = getCursorPosition()
-console.log("Cursor position is at ", cursorPosition)
-
 const parsedData = customParse();
 writeFileSync("parsedData.json", JSON.stringify(parsedData, 0, 2))
 
-
 let parsedNode = findNodeAt(parsedData, 64, 65, 'VariableDeclarator')
 // console.log(parsedNode)
+
+/*
+Returns the word just before the cursor.
+Returns '' if there is a space just before cursor instead of a word.
+*/
+export const getReferenceString = (fileContents, cursorPos) => {
+    var preCursorContent = fileContents.substring(0, cursorPos);
+    if (preCursorContent.indexOf(" ") > 0) {
+        const content = preCursorContent.split(" ");
+        return content[content.length - 1];
+    }
+    else {
+        return preCursorContent;
+    }
+}
 
 full(parsedData, node => {
     // console.log(`There's a ${node.type} node at ${node.ch}`)
@@ -91,3 +96,20 @@ ancestor(parsedData, {
 const cursorPos = 69;
 let node = findNodeAround(parsedData, cursorPos - 1)
 writeFileSync("currentCursorNode.json", JSON.stringify(node, 0, 2))
+
+export const returnSuggestions = () => {
+    //TODO
+    // check validity of input
+    const file = readInputFile()
+    const cursorPosition = getCursorPosition(file)
+    // no caret symbol found 
+    if (cursorPosition === -1) {
+        console.log("No cursor position (caret symbol) found \nSuggestions: []")
+        return []
+    }
+
+    console.log("Cursor position is at", cursorPosition)
+    console.log("Reference string is", getReferenceString(file, cursorPosition))
+}
+
+returnSuggestions()

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,21 @@ import { parse } from 'acorn-loose';
 import { readFileSync, writeFileSync } from 'fs';
 import { simple, full, ancestor, fullAncestor, findNodeAt, findNodeAround, findNodeAfter } from 'acorn-walk';
 
+const CURSOR_SYMBOL = '^'
+
 export const returnSuggestions = () => {
     //TODO
 }
 
+/* 
+Returns cursor position as denoted by CURSOR_SYMBOL if present
+Returns -1 if no cursor symbol present
+*/
 export const getCursorPosition = () => {
     //TODO
+    const fileContents = readInputFile()
+    const cursorPos = fileContents.indexOf(CURSOR_SYMBOL)
+    return cursorPos
 }
 
 const readInputFile = () => {
@@ -23,6 +32,9 @@ export const customParse = () => {
     return parsedResult
 }
 
+const cursorPosition = getCursorPosition()
+console.log("Cursor position is at ", cursorPosition)
+
 const parsedData = customParse();
 writeFileSync("parsedData.json", JSON.stringify(parsedData, 0, 2))
 
@@ -33,20 +45,20 @@ let parsedNode = findNodeAt(parsedData, 64, 65, 'VariableDeclarator')
 full(parsedData, node => {
     // console.log(`There's a ${node.type} node at ${node.ch}`)
 
-    if(node.type == 'Program'){
+    if (node.type == 'Program') {
         writeFileSync("fullWalk.json", JSON.stringify(node, 0, 2))
         parsedNode = node
     }
-  })
+})
 
 fullAncestor(parsedData, node => {
     // console.log(`There's a ${node.type} node at ${node.ch}`)
 
-    if(node.type == 'Program'){
+    if (node.type == 'Program') {
         writeFileSync("fullAncestor.json", JSON.stringify(node, 0, 2))
         parsedNode = node
     }
-  })
+})
 
 // Template code for future use
 // let nodeToPrint = ''

--- a/src/input.js
+++ b/src/input.js
@@ -6,7 +6,7 @@ import commonjs from "rollup-plugin-commonjs";
 import replace from "@rollup/plugin-replace";
 import license from "rollup-plugin-license";
 import pkg from "./package.json";
-
+const p
 function replaceVersion() {
   return replace({
     delimiters: ["", ""],
@@ -20,7 +20,7 @@ function licenseBanner() {
     commit = execSync("git rev-parse --short=10 HEAD")
       .toString()
       .trim();
-  } catch (e) {}
+  } catch (e) { }
   return license({
     banner: {
       content: { file: "./src/license.js" },
@@ -152,22 +152,22 @@ const umdPolyfills = {
   ]
 };
 
-const esPolyfills = {
+const esPolyfills^ = {
   input: "src/polyfills.js",
-  output: [
-    {
-      file: "dist/polyfills.es.js",
-      format: "es",
-      name: "jspdf-polyfills",
-      plugins: [terser({})]
-    }
-  ],
-  external: externals,
-  plugins: [licenseBanner()]
+    output: [
+      {
+        file: "dist/polyfills.es.js",
+        format: "es",
+        name: "jspdf-polyfills",
+        plugins: [terser({})]
+      }
+    ],
+      external: externals,
+        plugins: [licenseBanner()]
 };
 
 function matchSubmodules(externals) {
-  return externals.map(e => new RegExp(`^${e}(?:[/\\\\]|$)`));
+  return externals.map(e => new RegExp(`${e}(?:[/\\\\]|$)`));
 }
 
 export default [umd, es, node, umdPolyfills, esPolyfills];

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { returnSuggestions, getCursorPosition } from '../src/index.js'
+import { returnSuggestions, getCursorPosition, getReferenceString } from '../src/index.js'
 
 describe('returnSugestions (Acceptance Tests)', () => {
     it('should return empty list if file is empty', () => {
@@ -158,5 +158,19 @@ describe('getCursorPosition', () => {
     it('should return -1 if caret symbol not found', () => {
         const result = getCursorPosition(`const foo = c`);
         expect(result).to.equal(-1)
+    });
+});
+
+describe('getReferenceString', () => {
+    it('should return empty string if whitespace found before cursor pos', () => {
+        const file = "const foo ^"
+        const referenceString = getReferenceString(file, 10);
+        expect(referenceString).to.equal('')
+    });
+
+    it('should return correct string before cursor if no whitespace', () => {
+        const file = "const foo = bar^"
+        const referenceString = getReferenceString(file, 15);
+        expect(referenceString).to.equal('bar')
     });
 });


### PR DESCRIPTION
Feature: Cursor Position

- I am getting the cursor position by finding the index of caret (^) symbol. 

- getCursorPosition returns the first occurrence of the caret symbol, and -1 if it doesn't exist
- Fixed unit tests

Feature: Get String before cursor position

- getReferenceString returns the word just before the cursor, and empty string if there is whitespace. 
- Added unit tests

Removed the caret from the Regex expression in the input file.